### PR TITLE
Anchor upcoming events

### DIFF
--- a/views/eventgroup.handlebars
+++ b/views/eventgroup.handlebars
@@ -85,7 +85,7 @@
     {{{parsedDescription}}}
   </div>
 </div>
-<div class="card mt-4 mb-4">
+<div class="card mt-4 mb-4" id="upcomingEvents">
   <h5 class="card-header">Upcoming events</h5>
   <div class="list-group list-group-flush">
   {{#if upcomingEventsExist}}


### PR DESCRIPTION
> If you'll add #groupEvents to a div showing upcoming events you'll be able to share links scrolled straight to event list of your event group. It might come very handy for example when you embed it in <iframe> tag.
> Example url that scrolls automatically to an event list: https://gath.io/group/0HSOEdrcw#groupEvents

I personally think this can come really handy when you want to embed your events group on a website or share a straight link to upcoming events. And it's just a matter of adding a simple id selector in HTML file.