### PR TITLE
Allow names to be less than 3 characters

### DIFF
--- a/views/event.handlebars
+++ b/views/event.handlebars
@@ -169,7 +169,7 @@
       <div class="form-group">
         <label for="attendeeName">Your name</label>
         <div class="form-group">
-          <input type="text" class="form-control" id="attendeeName" name="attendeeName" placeholder="Or an alias, perhaps..." data-validation="required length" data-validation-length="3-30">
+          <input type="text" class="form-control" id="attendeeName" name="attendeeName" placeholder="Or an alias, perhaps..." data-validation="required length" data-validation-length="1-30">
         </div>
       </div>
       <div class="form-group">


### PR DESCRIPTION
There are names shorter than 3 characters such as "Jo", I don't see any reason for the minimum to be 3.