### PR TITLE
Fix event deletion

### DIFF
--- a/activitypub.js
+++ b/activitypub.js
@@ -341,8 +341,11 @@ function broadcastUpdateMessage(apObject, followers, eventID) {
 }
 
 function broadcastDeleteMessage(apObject, followers, eventID, callback) {
-  if (!isFederated) return;
   callback = callback || function () { };
+  if (!isFederated) {
+    callback([]);
+    return;
+  }
   // we need to build an array of promises for each message we're sending, run Promise.all(), and then that will resolve when every message has been sent (or failed)
   // per spec, each promise will execute *as it is built*, which is fine, we just need the guarantee that they are all done
   let promises = [];

--- a/views/event.handlebars
+++ b/views/event.handlebars
@@ -377,7 +377,7 @@
           <span aria-hidden="true">&times;</span>
         </button>
       </div>
-      <form id="deleteEventForm" action="/deleteevent/{{eventData.id}}" method="post">
+      <form id="deleteEventForm" action="/deleteevent/{{eventData.id}}/{{eventData.editToken}}" method="post">
       <div class="modal-body">
         <p>Are you sure you want to delete this event? This action cannot be undone.</p>
       </div>


### PR DESCRIPTION
Append editToken to the deleteEvent form action to fix 404 error on event deletion.

Refactor broadcastDeleteMessage so that eventDeletion works when federation is disabled. There's probably a less hacky way to do this.

Send deletion emails within the callback, otherwise DB lookup fails on deleted event id.

Fixes #84 