### PR TITLE
fix: only one CMD per Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ RUN npm install -g pnpm
 RUN pnpm install
 COPY . /app/
 RUN cp config/config.example.toml config/config.toml
-CMD pnpm run build
+RUN pnpm run build
 CMD pnpm run start


### PR DESCRIPTION
According to the [Dockerfile reference docs](https://docs.docker.com/engine/reference/builder/#cmd), there can only be one `CMD` instruction in a Dockerfile. If there is more than one, all but the last are skipped. This explains the error in #105, although fixing this particular issue does not get the docker build working properly since there are now TS errors being thrown in the build step (which was being skipped altogether previously). This PR leaves the #105 open, and addresses just the first issue by changing the `CMD` line to use `RUN`.