### PR TITLE
Update typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "eslint": "^8.40.0",
     "nodemon": "^2.0.22",
     "prettier": "^2.8.8",
-    "typescript": "^5.0.4"
+    "typescript": "5.1.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   '@sendgrid/mail':
     specifier: ^6.5.5
@@ -33,7 +37,7 @@ dependencies:
     version: 0.6.0
   ical-generator:
     specifier: ^1.15.4
-    version: 1.15.4
+    version: 1.15.4(@types/node@20.1.3)
   jimp:
     specifier: ^0.16.13
     version: 0.16.13
@@ -82,8 +86,8 @@ devDependencies:
     specifier: ^2.8.8
     version: 2.8.8
   typescript:
-    specifier: ^5.0.4
-    version: 5.0.4
+    specifier: 5.1.6
+    version: 5.1.6
 
 packages:
 
@@ -1623,12 +1627,13 @@ packages:
       sshpk: 1.17.0
     dev: false
 
-  /ical-generator@1.15.4:
+  /ical-generator@1.15.4(@types/node@20.1.3):
     resolution: {integrity: sha512-drXe4RLkfNlvDvdy/E6BUI9p+01L3ySK1ufNEYI9TxNKG9ZA3G60QWoZvD1dtmH4scwDxYu6/sZBPJvYVNrj8A==}
     engines: {node: '>=6.0.0'}
     peerDependencies:
       '@types/node': '>= 8.0.0'
     dependencies:
+      '@types/node': 20.1.3
       moment-timezone: 0.5.43
     dev: false
 
@@ -2783,9 +2788,9 @@ packages:
       mime-types: 2.1.35
     dev: false
 
-  /typescript@5.0.4:
-    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
-    engines: {node: '>=12.20'}
+  /typescript@5.1.6:
+    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
+    engines: {node: '>=14.17'}
     hasBin: true
     dev: true
 


### PR DESCRIPTION
The previous ^-based `typescript` version string in `package.json` installed 5.2.x automatically, but some changes in 5.2 break the build. I have updated this to explicitly install the latest 5.1 version, one that I have confirmed to work

I believe this fixes #107 