### PR TITLE
Disable discoverability/indexablity for ActivityPub actors

### DIFF
--- a/src/activitypub.js
+++ b/src/activitypub.js
@@ -34,8 +34,14 @@ export function createActivityPubActor(
         "@context": [
             "https://www.w3.org/ns/activitystreams",
             "https://w3id.org/security/v1",
+            {
+              "toot": "http://joinmastodon.org/ns#",
+              "discoverable": "toot:discoverable",
+              "indexable": "toot:indexable"
+            },
         ],
-
+        indexable: false,
+        discoverable: false,
         id: `https://${domain}/${eventID}`,
         type: "Person",
         preferredUsername: `${eventID}`,
@@ -45,7 +51,8 @@ export function createActivityPubActor(
         summary: `<p>${description}</p>`,
         name: name,
         featured: `https://${domain}/${eventID}/featured`,
-
+        indexable: false,
+        discoverable: false,
         publicKey: {
             id: `https://${domain}/${eventID}#main-key`,
             owner: `https://${domain}/${eventID}`,
@@ -82,7 +89,17 @@ export function createActivityPubEvent(
 ) {
     const guid = crypto.randomBytes(16).toString("hex");
     let eventObject = {
-        "@context": "https://www.w3.org/ns/activitystreams",
+        "@context": [
+            "https://www.w3.org/ns/activitystreams",
+            "https://w3id.org/security/v1",
+            {
+              "toot": "http://joinmastodon.org/ns#",
+              "discoverable": "toot:discoverable",
+              "indexable": "toot:indexable"
+            },
+        ],
+        indexable: false,
+        discoverable: false,
         id: `https://${domain}/${guid}`,
         name: name,
         type: "Event",


### PR DESCRIPTION
Applying the new `indexable` attribute (and the old `discoverable` attribute) to the main ActivityPub actor for a Gathio page as described here: https://github.com/mastodon/mastodon/pull/26485

Setting everything to false since Gathio is private-by-default.

Using the `toot` namespace since that seems safe enough. This commit from the Pixelfed repo making their service compatible with `indexable` is a good reference, but also we don't need to create our own namespace like they did. https://github.com/pixelfed/pixelfed/pull/4612

Fixes #116 