### PR TITLE
Fixed URLs in createEventGroup emails

### DIFF
--- a/views/emails/createEventGroup/createEventGroupHtml.handlebars
+++ b/views/emails/createEventGroup/createEventGroupHtml.handlebars
@@ -1,5 +1,5 @@
 <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">You just created a new event group on {{siteName}}! Thanks a bunch - we're delighted to have you.</p>
-<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">You can edit your event group by clicking the button below, or just following this link: <a href="https://{{domain}}/group/{{eventGroupID}}?e={{editToken}}">https://{{domain}}/{{eventGroupID}}?e={{editToken}}</a></p>
+<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">You can edit your event group by clicking the button below, or just following this link: <a href="https://{{domain}}/group/{{eventGroupID}}?e={{editToken}}">https://{{domain}}/group/{{eventGroupID}}?e={{editToken}}</a></p>
 <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">To add events to this group (whether brand new events or ones you've already made), click the 'This event is part of an event group' checkbox. You will need to copy the following two codes into the box which opens:</p>
 <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;"><strong>Event group ID</strong>: {{eventGroupID}}</p>
 <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;"><strong>Event group secret editing code</strong>: {{editToken}}</p>
@@ -18,7 +18,7 @@
     </tr>
   </tbody>
 </table>
-<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">To let others know about your event group, send them this link: <a href="https://{{domain}}/group/{{eventGroupID}}?e={{editToken}}">https://{{domain}}/{{eventGroupID}}</a></p>
+<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">To let others know about your event group, send them this link: <a href="https://{{domain}}/group/{{eventGroupID}}?e={{editToken}}">https://{{domain}}/group/{{eventGroupID}}</a></p>
 <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">And that's it - have a great day!</p>
 <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">Love,</p>
 <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">{{siteName}}</p>

--- a/views/emails/createEventGroup/createEventGroupText.handlebars
+++ b/views/emails/createEventGroup/createEventGroupText.handlebars
@@ -1,6 +1,6 @@
 You just created a new event group on {{siteName}}! Thanks a bunch - we're delighted to have you.
 
-You can edit your event group by clicking the button below, or just following this link: https://{{domain}}/{{eventGroupID}}?e={{editToken}}
+You can edit your event group by clicking the button below, or just following this link: https://{{domain}}/group/{{eventGroupID}}?e={{editToken}}
 
 To add events to this group (whether brand new events or ones you've already made), click the 'This event is part of an event group' checkbox. You will need to copy the following two codes into the box which opens:
 
@@ -10,7 +10,7 @@ Event group secret editing code: {{editToken}}
 
 Edit the event group here: https://{{domain}}/group/{{eventGroupID}}?e={{editToken}}
 
-To let others know about your event group, send them this link: https://{{domain}}/{{eventGroupID}}
+To let others know about your event group, send them this link: https://{{domain}}/group/{{eventGroupID}}
 
 And that's it - have a great day!
 


### PR DESCRIPTION
The links in the HTML emails worked fine, but the displayed URLs were missing the “group” part.
And in text version of the emails the links won't work (eg. if you copy/paste them).