### PR TITLE
Add NodeInfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gathio",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "",
     "main": "index.js",
     "type": "module",


### PR DESCRIPTION
This adds a `/.well-known/nodeinfo` endpoint to support the [NodeInfo standard](https://github.com/jhass/nodeinfo).