### PR TITLE
Optionally restrict event creation to specific email addresses

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -17,6 +17,11 @@ show_kofi = false
 # 'nodemailer' or 'sendgrid'. Configure settings for this mail
 # service below.
 mail_service = "nodemailer"
+# An array of email addresses which are permitted to create events. If this is
+# empty, anyone can create events.
+# For example:
+# creator_email_addresses = ["test@test.com", "admin@test.com"]
+creator_email_addresses = []
 
 [database]
 # Set up for a locally running MongoDB connection. Change this to

--- a/public/js/modules/new.js
+++ b/public/js/modules/new.js
@@ -119,6 +119,10 @@ function newEventForm() {
                 "imageUpload",
                 this.$refs.eventImageUpload.files[0],
             );
+            formData.append(
+                "magicLinkToken",
+                this.$refs.magicLinkToken.value,
+            );
             try {
                 const response = await fetch("/event", {
                     method: "POST",
@@ -170,6 +174,10 @@ function newEventGroupForm() {
                 "imageUpload",
                 this.$refs.eventGroupImageUpload.files[0],
             );
+            formData.append(
+                "magicLinkToken",
+                this.$refs.magicLinkToken.value,
+            );
             try {
                 const response = await fetch("/group", {
                     method: "POST",
@@ -217,6 +225,10 @@ function importEventForm() {
             formData.append(
                 "icsImportControl",
                 this.$refs.icsImportControl.files[0],
+            );
+            formData.append(
+                "magicLinkToken",
+                this.$refs.magicLinkToken.value,
             );
             try {
                 const response = await fetch("/import/event", {

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,7 @@ import activitypub from "./routes/activitypub.js";
 import event from "./routes/event.js";
 import group from "./routes/group.js";
 import staticPages from "./routes/static.js";
+import magicLink from "./routes/magicLink.js";
 
 import { initEmailService } from "./lib/email.js";
 import {
@@ -63,6 +64,7 @@ app.use("/", frontend);
 app.use("/", activitypub);
 app.use("/", event);
 app.use("/", group);
+app.use("/", magicLink);
 app.use("/", routes);
 
 export default app;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -18,6 +18,7 @@ interface GathioConfig {
         email_logo_url: string;
         show_kofi: boolean;
         mail_service: "nodemailer" | "sendgrid";
+        creator_email_addresses: string[];
     };
     database: {
         mongodb_url: string;

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -12,6 +12,7 @@ type EmailTemplate =
     | "addEventComment"
     | "createEvent"
     | "createEventGroup"
+    | "createEventMagicLink"
     | "deleteEvent"
     | "editEvent"
     | "eventGroupUpdated"

--- a/src/lib/middleware.ts
+++ b/src/lib/middleware.ts
@@ -1,0 +1,51 @@
+import { Request, Response } from "express";
+import MagicLink from "../models/MagicLink.js";
+import getConfig from "../lib/config.js";
+
+const config = getConfig();
+
+export const checkMagicLink = async (
+    req: Request,
+    res: Response,
+    next: any,
+) => {
+    if (!config.general.creator_email_addresses?.length) {
+        // No creator email addresses are configured, so skip the magic link check
+        return next();
+    }
+    if (!req.body.magicLinkToken) {
+        return res.status(400).json({
+            errors: [
+                {
+                    message: "No magic link token was provided.",
+                },
+            ],
+        });
+    }
+    if (!req.body.creatorEmail) {
+        return res.status(400).json({
+            errors: [
+                {
+                    message: "No creator email was provided.",
+                },
+            ],
+        });
+    }
+    const magicLink = await MagicLink.findOne({
+        token: req.body.magicLinkToken,
+        email: req.body.creatorEmail,
+        expiryTime: { $gt: new Date() },
+        permittedActions: "createEvent",
+    });
+    if (!magicLink || magicLink.email !== req.body.creatorEmail) {
+        return res.status(400).json({
+            errors: [
+                {
+                    message:
+                        "Magic link is invalid or has expired. Get a new one <a href='/new'>here</a>.",
+                },
+            ],
+        });
+    }
+    next();
+};

--- a/src/models/MagicLink.ts
+++ b/src/models/MagicLink.ts
@@ -1,0 +1,35 @@
+import mongoose from "mongoose";
+
+export type MagicLinkAction = "createEvent";
+
+export interface MagicLink {
+    id: string;
+    email: string;
+    token: string;
+    expiryTime: Date;
+    permittedActions: MagicLinkAction[];
+}
+
+const MagicLinkSchema = new mongoose.Schema({
+    email: {
+        type: String,
+        trim: true,
+        required: true,
+    },
+    token: {
+        type: String,
+        trim: true,
+        required: true,
+    },
+    expiryTime: {
+        type: Date,
+        trim: true,
+        required: true,
+    },
+    permittedActions: {
+        type: [String],
+        required: true,
+    },
+});
+
+export default mongoose.model<MagicLink>("MagicLink", MagicLinkSchema);

--- a/src/routes/event.ts
+++ b/src/routes/event.ts
@@ -26,6 +26,7 @@ import { sendEmailFromTemplate } from "../lib/email.js";
 import crypto from "crypto";
 import ical from "ical";
 import { markdownToSanitizedHTML } from "../util/markdown.js";
+import { checkMagicLink } from "../lib/middleware.js";
 
 const config = getConfig();
 
@@ -60,6 +61,7 @@ const router = Router();
 router.post(
     "/event",
     upload.single("imageUpload"),
+    checkMagicLink,
     async (req: Request, res: Response) => {
         const { data: eventData, errors } = validateEventData(req.body);
         if (errors && errors.length > 0) {
@@ -527,6 +529,7 @@ router.put(
 router.post(
     "/import/event",
     icsUpload.single("icsImportControl"),
+    checkMagicLink,
     async (req: Request, res: Response) => {
         if (!req.file) {
             return res.status(400).json({

--- a/src/routes/group.ts
+++ b/src/routes/group.ts
@@ -9,6 +9,7 @@ import EventGroup from "../models/EventGroup.js";
 import { sendEmailFromTemplate } from "../lib/email.js";
 import { marked } from "marked";
 import { renderPlain } from "../util/markdown.js";
+import { checkMagicLink } from "../lib/middleware.js";
 
 const config = getConfig();
 
@@ -32,6 +33,7 @@ const router = Router();
 router.post(
     "/group",
     upload.single("imageUpload"),
+    checkMagicLink,
     async (req: Request, res: Response) => {
         const { data: groupData, errors } = validateGroupData(req.body);
         if (errors && errors.length > 0) {

--- a/src/routes/magicLink.ts
+++ b/src/routes/magicLink.ts
@@ -1,0 +1,70 @@
+import { Router, Request, Response } from "express";
+import getConfig, { frontendConfig } from "../lib/config.js";
+import { sendEmailFromTemplate } from "../lib/email.js";
+import { generateMagicLinkToken } from "../util/generator.js";
+import MagicLink from "../models/MagicLink.js";
+
+const router = Router();
+const config = getConfig();
+
+router.post("/magic-link/event/create", async (req: Request, res: Response) => {
+    const { email } = req.body;
+    if (!email) {
+        res.render("createEventMagicLink", {
+            ...frontendConfig(),
+            message: {
+                type: "danger",
+                text: "Please provide an email address.",
+            },
+        });
+        return;
+    }
+    const allowedEmails = config.general.creator_email_addresses;
+    if (!allowedEmails?.length) {
+        // No creator email addresses are configured, so skip the magic link check
+        return res.redirect("/new");
+    }
+    if (!allowedEmails.includes(email)) {
+        res.render("createEventMagicLink", {
+            ...frontendConfig(),
+            message: {
+                type: "success",
+                text: "Thanks! If this email address can create events, you should receive an email with a magic link.",
+            },
+        });
+        return;
+    }
+    const token = generateMagicLinkToken();
+    const magicLink = new MagicLink({
+        email,
+        token,
+        expiryTime: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24 hours
+        permittedActions: ["createEvent"],
+    });
+    await magicLink.save();
+
+    // Take this opportunity to delete any expired magic links
+    await MagicLink.deleteMany({ expiryTime: { $lt: new Date() } });
+
+    sendEmailFromTemplate(
+        email,
+        `Magic link to create an event`,
+        "createEventMagicLink",
+        {
+            token,
+            siteName: config.general.site_name,
+            siteLogo: config.general.email_logo_url,
+            domain: config.general.domain,
+        },
+        req,
+    );
+    res.render("createEventMagicLink", {
+        ...frontendConfig(),
+        message: {
+            type: "success",
+            text: "Thanks! If this email address can create events, you should receive an email with a magic link.",
+        },
+    });
+});
+
+export default router;

--- a/src/util/generator.ts
+++ b/src/util/generator.ts
@@ -19,6 +19,8 @@ export const generateEventID = () => nanoid();
 
 export const generateEditToken = () => generateAlphanumericString(32);
 
+export const generateMagicLinkToken = () => generateAlphanumericString(32);
+
 export const generateRSAKeypair = () => {
     return crypto.generateKeyPairSync("rsa", {
         modulusLength: 4096,

--- a/views/createEventMagicLink.handlebars
+++ b/views/createEventMagicLink.handlebars
@@ -1,0 +1,30 @@
+<article>
+
+  <h3 class="mb-4">Request a link to create a new event</h3>
+
+  <form
+    action="/magic-link/event/create"
+    method="post"
+    hx-post="/magic-link/event/create"
+    hx-target="article"
+  >
+    <p>
+      The administrator of this instance has limited event creation to a set of specific email addresses. If your email address is allowed to create events, you will be sent a magic link to create an event. If not, you won't receive anything.
+    </p>
+    <p>
+      If you run into any issues, please contact the instance administrator.
+    </p>
+    {{#if message}}
+      <div class="alert alert-{{message.type}}" role="alert">
+        {{message.text}}
+      </div>
+    {{/if}}
+    <div class="form-group">
+      <label for="email">Email address</label>
+    <input type="email" class="form-control" id="email" placeholder="Email address" required name="email">
+    </div>
+    <div class="form-group text-center">
+      <button type="submit" class="btn btn-primary w-50">Request magic link</button>
+    </div>
+  </form>
+</article>

--- a/views/emails/createEventMagicLink/createEventMagicLinkHtml.handlebars
+++ b/views/emails/createEventMagicLink/createEventMagicLinkHtml.handlebars
@@ -1,0 +1,8 @@
+<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">Here's a magic link which will allow you to create an event on {{siteName}}.</p>
+<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">This link will expire in 24 hours and can be used multiple times before then. Don't share it publicly, because it will allow anyone to create an event on your behalf!</p>
+<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;"><a href="https://{{domain}}/new/{{token}}">https://{{domain}}/new/{{token}}</a></p>
+<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">Love,</p>
+<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">{{siteName}}</p>
+<hr/>
+<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;"><strong>Hold up - I have no idea what this email is about!</strong></p>
+<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">If you didn't try to create an event on {{siteName}}, someone may have accidentally typed your email instead of theirs. Don't worry - there isn't anything you need to do. Your email address will be deleted after the magic link expires.</p>

--- a/views/emails/createEventMagicLink/createEventMagicLinkText.handlebars
+++ b/views/emails/createEventMagicLink/createEventMagicLinkText.handlebars
@@ -1,0 +1,11 @@
+Here's a magic link which will allow you to create an event on {{siteName}}.
+
+This link will expire in 24 hours and can be used multiple times before then. Don't share it publicly, because it will allow anyone to create an event on your behalf!
+
+https://{{domain}}/new/{{token}}
+
+Love,
+
+{{siteName}}
+
+If you didn't try to create an event on {{siteName}}, someone may have accidentally typed your email instead of theirs. Don't worry - there isn't anything you need to do. Your email address will be deleted after the magic link expires.

--- a/views/partials/eventForm.handlebars
+++ b/views/partials/eventForm.handlebars
@@ -1,3 +1,4 @@
+<input type="hidden" name="magicLinkToken" value="{{magicLinkToken}}" x-ref="magicLinkToken">
 <div class="form-group">
   <label for="eventName" >Event name</label>
   <div class="form-group ">
@@ -65,7 +66,7 @@
 <div class="form-group">
   <label for="creatorEmail" >Your email</label>
   <div class="form-group ">
-    <input type="email" class="form-control" id="creatorEmail" name="creatorEmail" placeholder="Will not be shown anywhere (optional)." x-model="data.creatorEmail" >
+    <input type="email" class="form-control" id="creatorEmail" name="creatorEmail" placeholder="Will not be shown anywhere (optional)." x-model.fill="data.creatorEmail" {{#if creatorEmail}}value="{{creatorEmail}}" readonly{{/if}}>
     <small class="form-text">If you provide your email, we will send your secret editing password here, and use it to notify you of updates to the event.</small>
   </div>
 </div>
@@ -159,7 +160,7 @@
       <p><i class="fas fa-exclamation-triangle"></i> Please fix these errors:</p>
       <ul>
         <template x-for="error in errors">
-          <li x-text="error.message"></li>
+          <li x-html="error.message"></li>
         </template>
       </ul>
     </div>

--- a/views/partials/eventGroupForm.handlebars
+++ b/views/partials/eventGroupForm.handlebars
@@ -1,3 +1,4 @@
+<input type="hidden" name="magicLinkToken" value="{{magicLinkToken}}" x-ref="magicLinkToken">
 <div class="form-group">
     <label for="eventGroupName">Name</label>
     <input type="text" class="form-control" id="eventGroupName" name="eventGroupName" placeholder="Make it snappy." x-model="data.eventGroupName">
@@ -18,7 +19,7 @@
 <div class="form-group">
     <label for="creatorEmail">Your email</label>
     <div class="form-group">
-        <input type="email" class="form-control" id="eventGroupCreatorEmail" name="creatorEmail" placeholder="Will not be shown anywhere (optional)." x-model="data.creatorEmail">
+        <input type="email" class="form-control" id="eventGroupCreatorEmail" name="creatorEmail" placeholder="Will not be shown anywhere (optional)." x-model.fill="data.creatorEmail" {{#if creatorEmail}}value="{{creatorEmail}}" readonly{{/if}}>
         <small class="form-text">If you provide your email, we will send your secret editing password here, and use it to notify you of updates to the event.</small>
     </div>
 </div>
@@ -40,7 +41,7 @@
       <p><i class="fas fa-exclamation-triangle"></i> Please fix these errors:</p>
       <ul>
         <template x-for="error in errors">
-          <li x-text="error.message"></li>
+          <li x-html="error.message"></li>
         </template>
       </ul>
     </div>

--- a/views/partials/importeventform.handlebars
+++ b/views/partials/importeventform.handlebars
@@ -6,6 +6,7 @@
 <img class="img-thumbnail mb-3 d-block mx-auto" src="/images/facebook-export.png" alt="Image showing the location of the export option on Facebook" />
 
 <form id="icsImportForm" enctype="multipart/form-data" x-data="importEventForm()" @submit.prevent="submitForm">
+  <input type="hidden" name="magicLinkToken" value="{{magicLinkToken}}" x-ref="magicLinkToken">
   <div class="form-group">
     <div class="custom-file" id="icsImportContainer">
     <input required name="icsImportControl" type="file" class="custom-file-input" id="icsImportControl" aria-describedby="fileHelp" accept="text/calendar" x-ref="icsImportControl"/>
@@ -17,7 +18,7 @@
   <div class="form-group">
     <label for="creatorEmail" class="form-label">Your email</label>
     <div class="form-group">
-      <input type="email" class="form-control" id="importCreatorEmail" name="creatorEmail" placeholder="Will not be shown anywhere (optional)." x-model="data.creatorEmail" >
+      <input type="email" class="form-control" id="importCreatorEmail" name="creatorEmail" placeholder="Will not be shown anywhere (optional)." x-model.fill="data.creatorEmail" {{#if creatorEmail}}value="{{creatorEmail}}" readonly{{/if}}>
     <small class="form-text">If you provide your email, we will send your secret editing password here, and use it to notify you of updates to the event.</small>
     </div>
   </div>
@@ -31,7 +32,7 @@
         <p><i class="fas fa-exclamation-triangle"></i> Please fix these errors:</p>
         <ul>
           <template x-for="error in errors">
-            <li x-text="error.message"></li>
+            <li x-html="error.message"></li>
           </template>
         </ul>
       </div>


### PR DESCRIPTION
This fulfills the feature request in https://github.com/lowercasename/gathio/issues/1 (our first ever issue! Better late than never!) to optionally restrict event creation to a set of whitelisted email addresses.

In the config file you can now specify an array:

```
creator_email_addresses = ["test@test.com", "admin@test.com"]
```

If this array is not blank, navigating to `/new` will instead navigate to a form where the user can enter their email address. If that email address is in the whitelist, they get an email with a magic link (saved in a new `magiclinks` collection in the database), which will allow them to go to the actual event/group creation forms. Whether the email exists or not, the user gets the same success message back, to prevent enumeration attacks.

Magic links are only checked for event and group creation and event import. They're not relevant for event editing - which of course uses its own editing tokens.