### PR TITLE
Set number of days to store concluded events (including permanently!)

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -6,6 +6,9 @@ port = "3000"
 email = "contact@example.com"
 site_name = "gathio"
 is_federated = true
+# Events will be deleted this many days after they have ended. Set to 0 to
+# disable automatic deletion (old events will never be deleted).
+delete_after_days = 7
 # If left blank, this defaults to
 # https://yourdomain.com/images/gathio-email-logo.gif. Set a full URL here to
 # change it to your own logo (or just change the file itself).

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -14,6 +14,7 @@ interface GathioConfig {
         port: string;
         email: string;
         site_name: string;
+        delete_after_days: number | null;
         is_federated: boolean;
         email_logo_url: string;
         show_kofi: boolean;
@@ -32,7 +33,7 @@ interface GathioConfig {
     sendgrid?: {
         api_key: string;
     };
-    static_pages: StaticPage[];
+    static_pages?: StaticPage[];
 }
 
 interface FrontendConfig {
@@ -42,9 +43,26 @@ interface FrontendConfig {
     emailLogoUrl: string;
     showKofi: boolean;
     showInstanceInformation: boolean;
-    staticPages: StaticPage[];
+    staticPages?: StaticPage[];
     version: string;
 }
+
+const defaultConfig: GathioConfig = {
+    general: {
+        domain: "localhost:3000",
+        email: "contact@example.com",
+        port: "3000",
+        site_name: "gathio",
+        is_federated: true,
+        delete_after_days: 7,
+        email_logo_url: "",
+        show_kofi: false,
+        mail_service: "nodemailer",
+    },
+    database: {
+        mongodb_url: "mongodb://localhost:27017/gathio",
+    },
+};
 
 export const frontendConfig = (): FrontendConfig => {
     const config = getConfig();
@@ -54,7 +72,7 @@ export const frontendConfig = (): FrontendConfig => {
         isFederated: config.general.is_federated,
         emailLogoUrl: config.general.email_logo_url,
         showKofi: config.general.show_kofi,
-        showInstanceInformation: config.static_pages?.length > 0,
+        showInstanceInformation: !!config.static_pages?.length,
         staticPages: config.static_pages,
         version: process.env.npm_package_version || "unknown",
     };
@@ -67,7 +85,10 @@ export const getConfig = (): GathioConfig => {
         const config = toml.parse(
             fs.readFileSync("./config/config.toml", "utf-8"),
         ) as GathioConfig;
-        return config;
+        return {
+            ...defaultConfig,
+            ...config,
+        };
     } catch {
         exitWithError(
             "Configuration file not found! Have you renamed './config/config-example.toml' to './config/config.toml'?",

--- a/src/routes.js
+++ b/src/routes.js
@@ -82,7 +82,13 @@ router.use(fileUpload());
 
 // SCHEDULED DELETION
 schedule.scheduleJob("59 23 * * *", function (fireDate) {
-    const too_old = moment.tz("Etc/UTC").subtract(7, "days").toDate();
+    const deleteAfterDays = config.general.delete_after_days;
+    if (!deleteAfterDays || deleteAfterDays <= 0) {
+        // Deletion is disabled
+        return;
+    }
+
+    const too_old = moment.tz("Etc/UTC").subtract(deleteAfterDays, "days").toDate();
     console.log(
         "Old event deletion running! Deleting all events concluding before ",
         too_old,


### PR DESCRIPTION
Using the config file option `delete_after_days`, users can now specify how many days to wait before concluded events are deleted. The default is 7, and if the option is set to 0, events will be stored permanently and never auto-deleted.