### PR TITLE
Unattend events from RSVP email

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2689,6 +2689,7 @@ packages:
 
   /memory-pager@1.5.0:
     resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
+    requiresBuild: true
     dev: false
     optional: true
 
@@ -3617,6 +3618,7 @@ packages:
 
   /sparse-bitfield@3.0.3:
     resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
+    requiresBuild: true
     dependencies:
       memory-pager: 1.5.0
     dev: false

--- a/src/routes.js
+++ b/src/routes.js
@@ -23,6 +23,7 @@ import Event from "./models/Event.js";
 import EventGroup from "./models/EventGroup.js";
 import path from "path";
 import { activityPubContentType } from "./lib/activitypub.js";
+import { hashString } from "./util/generator.js";
 
 const config = getConfig();
 const domain = config.general.domain;
@@ -713,6 +714,7 @@ router.post("/attendevent/:eventID", async (req, res) => {
                             siteLogo,
                             domain,
                             removalPassword: req.body.removalPassword,
+                            removalPasswordHash: hashString(req.body.removalPassword),
                             cache: true,
                             layout: "email.handlebars",
                         },

--- a/src/routes/frontend.ts
+++ b/src/routes/frontend.ts
@@ -12,6 +12,7 @@ import {
 } from "../lib/activitypub.js";
 import MagicLink from "../models/MagicLink.js";
 import { getConfigMiddleware } from "../lib/middleware.js";
+import { getMessage } from "../util/messages.js";
 
 const router = Router();
 
@@ -377,6 +378,7 @@ router.get("/:eventID", async (req: Request, res: Response) => {
                     image: event.image,
                     editToken: editingEnabled ? eventEditToken : null,
                 },
+                message: getMessage(req.query.m as string),
             });
         }
     } catch (err) {

--- a/src/util/generator.ts
+++ b/src/util/generator.ts
@@ -34,3 +34,6 @@ export const generateRSAKeypair = () => {
         },
     });
 };
+
+export const hashString = (input: string) =>
+    crypto.createHash("sha256").update(input).digest("hex");

--- a/src/util/messages.ts
+++ b/src/util/messages.ts
@@ -1,0 +1,9 @@
+type MessageId = "unattend";
+
+const queryStringMessages: Record<MessageId, string> = {
+    unattend: `You have been removed from this event.`,
+};
+
+export const getMessage = (id?: string) => {
+    return queryStringMessages[id as MessageId] || "";
+};

--- a/views/emails/addEventAttendee/addEventAttendeeHtml.handlebars
+++ b/views/emails/addEventAttendee/addEventAttendeeHtml.handlebars
@@ -1,6 +1,7 @@
 <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">You just marked yourself as attending an event on {{siteName}}. Thank you! We'll send you another email if there are any updates to the event. Your email will be automatically removed from the database once the event finishes.</p>
 <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">Follow this link to open the event page any time: <a href="https://{{domain}}/{{eventID}}">https://{{domain}}/{{eventID}}</a></p>
-<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">Need to remove yourself from this event? Head to the event page and use this <strong>deletion password</strong>: {{removalPassword}}</p>
+<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">Need to remove yourself from this event? <a href="https://{{domain}}/event/{{eventID}}/unattend/{{removalPasswordHash}}">Click this link</a>.</p>
+<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">You can also head to the event page and use this <strong>deletion password</strong>: {{removalPassword}}</p>
 <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">Love,</p>
 <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">{{siteName}}</p>
 <hr/>

--- a/views/emails/addEventAttendee/addEventAttendeeText.handlebars
+++ b/views/emails/addEventAttendee/addEventAttendeeText.handlebars
@@ -2,7 +2,9 @@ You just marked yourself as attending an event on {{siteName}}. Thank you! We'll
 
 Follow this link to open the event page any time: https://{{domain}}/{{eventID}}
 
-Need to remove yourself from this event? Head to the event page and use this deletion password: {{removalPassword}}
+Need to remove yourself from this event? Click this link: https://{{domain}}/event/{{eventID}}/unattend/{{removalPasswordHash}}
+
+You can also head to the event page and use this deletion password: {{removalPassword}}
 
 Love,
 

--- a/views/emails/unattendEvent/unattendEventHtml.handlebars
+++ b/views/emails/unattendEvent/unattendEventHtml.handlebars
@@ -1,5 +1,5 @@
 <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">You just removed yourself from an event on {{siteName}}. You will no longer receive update emails for this event.</p>
-<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">If you didn't mean to do this, someone else who knows your email removed you from the event.</p>
+<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">If you didn't mean to do this, an admin may have removed you from the event.</p>
 <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">Follow this link to open the event page any time: <a href="https://{{domain}}/{{eventID}}">https://{{domain}}/{{eventID}}</a></p>
 <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">Love,</p>
 <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">{{siteName}}</p>

--- a/views/emails/unattendEvent/unattendEventText.handlebars
+++ b/views/emails/unattendEvent/unattendEventText.handlebars
@@ -1,6 +1,6 @@
 You just removed yourself from an event on {{siteName}}. You will no longer receive update emails for this event.
 
-If you didn't mean to do this, someone else who knows your email removed you from the event.
+If you didn't mean to do this, an admin may have removed you from the event.
 
 Follow this link to open the event page any time: https://{{domain}}/{{eventID}}
 

--- a/views/event.handlebars
+++ b/views/event.handlebars
@@ -17,6 +17,11 @@
     {{/if}}
   </div>
 </div>
+{{#if message}}
+<div class="alert alert-info mt-3 text-center" role="alert" id="event__message">
+    {{message}}
+</div>
+{{/if}}
 <div id="event__basics">
   <div class="card" id="event__data">
     <div class="card-body">
@@ -207,7 +212,7 @@
       </div>
       <div class="form-group">
         <label for="removalPassword">Deletion password</label>
-        <p class="form-text small">You will need this password if you want to remove yourself from the list of event attendees. If you provided your email, you'll receive it by email. Otherwise, write it down now because it will <strong>not be shown again</strong>.</p>
+        <p class="form-text small">You can use this password to remove yourself from the list of event attendees. If you provided your email, you'll receive it by email. Otherwise, write it down now because it will <strong>not be shown again</strong>.</p>
         <input type="text" class="form-control" readonly id="removalPassword"
         name="removalPassword">
       </div>
@@ -456,7 +461,9 @@ window.eventData = {{{ json jsonData }}};
         error: function(response, status, xhr) {
           // The editing token is wrong - remove it
           removeStoredToken(eventID);
-          window.location = window.location.pathname;
+          // Remove the token from the URL
+          url.searchParams.delete('e');
+          window.location = url.href;
         }
       });
     } else if (getStoredToken(eventID)) {
@@ -467,6 +474,9 @@ window.eventData = {{{ json jsonData }}};
         data: { editToken },
         success: function(response, status, xhr) {
           if (xhr.status === 200) {
+            // Redirect to the same URL with the editing token in the URL
+            // We reload the page to force the server to load a page with
+            // the editing form accessible.
             window.location.search = `?e=${editToken}`;
           }
         },
@@ -479,7 +489,12 @@ window.eventData = {{{ json jsonData }}};
 
     if (urlParams.has('show_edit')) {
       $('#editModal').modal('show');
-      url.searchParams.delete('show_edit'); 
+      url.searchParams.delete('show_edit');
+      history.replaceState(history.state, '', url.href);
+    }
+
+    if (urlParams.has('m')) {
+      url.searchParams.delete('m');
       history.replaceState(history.state, '', url.href);
     }
 
@@ -538,7 +553,7 @@ window.eventData = {{{ json jsonData }}};
               .attr('data-validation-allowing', `range[1;${response.data.freeSpots}]`)
               .attr('data-validation-error-msg', `Please enter a number between 1 and ${response.data.freeSpots}`);
           }
-          modal.modal(); 
+          modal.modal();
         })
         .catch((error) => {
           console.error(error);


### PR DESCRIPTION
Adds a new feature as suggested in https://github.com/lowercasename/gathio/issues/145: when the RSVP email is sent to an attendee, it contains a link to quickly un-RSVP from the event. The link leads to a new endpoint which takes the event ID and the hash of the RSVP password.

I also added the beginnings of a library to show error/success messages on pages.