### PR TITLE
Docker volume for 'events' folder

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,8 @@ services:
             - 3000:3000
         volumes:
             # Set the correct path to the config folder
-            - ./gathio-docker:/app/config
+            - ./gathio-docker/config:/app/config
+            - ./gathio-docker/events:/app/public/events
     mongo:
         image: mongo:latest
         volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,9 @@ services:
         ports:
             - 3000:3000
         volumes:
-            # Set the correct path to the config folder
+            # The path to Gathio's config folder - change to match your system
             - ./gathio-docker/config:/app/config
+            # The path to Gathio's user-uploaded event images folder - change to match your system
             - ./gathio-docker/events:/app/public/events
     mongo:
         image: mongo:latest


### PR DESCRIPTION
Added docker-compose example for mounting a volume for the /app/public/events directory. This can be helpful because rebuilding the docker image per instructions causes user-uploaded images to be lost. Using a persistent volume prevents this data loss when rebuilding.