### PR TITLE
Allow self-signed certs for SMTP server

### DIFF
--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -54,6 +54,10 @@ export const initEmailService = async (): Promise<boolean> => {
                     user: config.nodemailer?.smtp_username,
                     pass: config.nodemailer?.smtp_password,
                 },
+                tls: { 
+                    // do not fail on invalid certs
+                    rejectUnauthorized: false,
+                },
             } as SMTPTransport.Options;
             const nodemailerTransporter =
                 nodemailer.createTransport(nodemailerConfig);


### PR DESCRIPTION
Added "tls:" property of  'rejectUnauthorized: false' to allow program to continue startup when SMTP certificates are not able to be validated against known trusted roots.