### PR TITLE
Change wiki links to new docs site.

### DIFF
--- a/src/activitypub.js
+++ b/src/activitypub.js
@@ -127,7 +127,7 @@ export function createFeaturedPost(
         type: "Note",
         name: "Test",
         cc: "https://www.w3.org/ns/activitystreams#Public",
-        content: `<p>This is an event that was posted on <a href="https://${domain}/${eventID}">${siteName}</a>. If you follow this account, you'll see updates in your timeline about the event. If your software supports polls, you should get a poll in your DMs asking if you want to RSVP. You can reply and RSVP right from there. If your software has an event calendar built in, you should get an event in your inbox that you can RSVP to like you respond to any event.</p><p>For more information on how to interact with this, <a href="https://github.com/lowercasename/gathio/wiki/Fediverse-Instructions">check out this link</a>.</p>`,
+        content: `<p>This is an event that was posted on <a href="https://${domain}/${eventID}">${siteName}</a>. If you follow this account, you'll see updates in your timeline about the event. If your software supports polls, you should get a poll in your DMs asking if you want to RSVP. You can reply and RSVP right from there. If your software has an event calendar built in, you should get an event in your inbox that you can RSVP to like you respond to any event.</p><p>For more information on how to interact with this, <a href="https://docs.gath.io/using-gathio/fediverse/">check out this link</a>.</p>`,
         attributedTo: `https://${domain}/${eventID}`,
     };
     return featured;

--- a/views/home.handlebars
+++ b/views/home.handlebars
@@ -1,54 +1,72 @@
 <main class="page">
-<h2 class="mb-3 pb-2 text-center border-bottom">About {{siteName}}</h2>
+  <h2 class="mb-3 pb-2 text-center border-bottom">About {{siteName}}</h2>
 
-{{#if instanceDescription}}
-    <div class="instance-description mb-4">
-        {{{instanceDescription}}}
-    </div>
-{{/if}}
-
-{{> instanceRules }}
-
-<h2 class="mb-3 mt-5 pb-2 text-center border-bottom">About Gathio</h2>
-
-<p class="lead text-center">Gathio is a simple, federated, privacy-first event hosting platform.</p>
-
-<div id="example-event" class="text-center w-100 mt-4 mb-5">
-  <img alt ="An example event page for a picnic. The page shows the event's location, host, date and time, and description, as well as buttons to save the event to Google Calendar, export it, and open the location in OpenStreetMap and Google Maps." src="images/example-event-2023.png" class="img-fluid w-75 mx-auto shadow-lg rounded">
-</div>
-
-<h3>Privacy-first</h3>
-
-<p>There are no accounts on Gathio. When you create an event, we generate a password which allows you to edit the event. Send all your guests the public link, and all your co-hosts the secret editing link containing the password.</p>
-
-<p>If you supply your email, we'll send you the editing password so you don't lose it - but supplying your email is optional!</p>
-
-<p>If this instance automatically deletes its events, sometime after the event finishes, it's deleted from the database for ever, and your data goes with it.</p>
-
-<p>Also, Gathio doesn't show you ads, doesn't sell your data, and never sends you unnecessary emails.</p>
-
-<p>But remember: all events are visible to anyone who knows the link, so probably don't use Gathio to plot your surprise birthday party or revolution. Or whatever, you do you.</p>
-
-<h3>Configurable</h3>
-
-<p>The <a href="https://gath.io">flagship Gathio instance at gath.io</a> is designed for anyone to create ephemeral, hidden events. Anyone can create an event; events are never displayed anywhere public; and they're deleted 7 days after they end.</p>
-
-<p>But if your community sets up their own instance, you can limit event creation to a specific list of people, display events on a handy list on the homepage, and disable event deletion entirely!</p>
-
-<h3>Federation and self-hosting</h3>
-
-<p>Gathio can easily be self-hosted, and supports ActivityPub services like Mastodon, Pleroma, and Friendica, allowing you to access events from anywhere on the Fediverse. We encourage you to spin up your own instance for your community. Detailed instructions on <a href="https://github.com/lowercasename/gathio/wiki/Fediverse-Instructions">ActivityPub access</a> and <a href="https://github.com/lowercasename/gathio/wiki/Installation-instructions">self-hosted installation</a> live on our GitHub wiki.
-
-<h3>Open source</h3>
-
-<p>Gathio is delighted to be open source, and is built by a lovely group of people. Leave a question in our <a href="https://github.com/lowercasename/gathio/issues">tracker</a> if you encounter any issues.</p>
-
-{{#if showKofi}}
-<div class="card border-secondary mt-5 mb-3 mx-auto" style="min-width:300px;max-width:50%;">
-  <div class="card-body text-secondary">
-    <p>If you find yourself using and enjoying Gathio, consider buying Raphael a coffee. It'll help keep the project and main site running! <i class="far fa-heart"></i></p>
-    <script type='text/javascript' src='https://ko-fi.com/widgets/widget_2.js'></script><script type='text/javascript'>kofiwidget2.init('Support Me on Ko-fi', '#46b798', 'Q5Q2O7T5');kofiwidget2.draw();</script>
+  {{#if instanceDescription}}
+  <div class="instance-description mb-4">
+    {{{instanceDescription}}}
   </div>
-</div>
-{{/if}}
+  {{/if}}
+
+  {{> instanceRules }}
+
+  <h2 class="mb-3 mt-5 pb-2 text-center border-bottom">About Gathio</h2>
+
+  <p class="lead text-center">Gathio is a simple, federated, privacy-first event hosting platform.</p>
+
+  <div id="example-event" class="text-center w-100 mt-4 mb-5">
+    <img
+      alt="An example event page for a picnic. The page shows the event's location, host, date and time, and description, as well as buttons to save the event to Google Calendar, export it, and open the location in OpenStreetMap and Google Maps."
+      src="images/example-event-2023.png" class="img-fluid w-75 mx-auto shadow-lg rounded">
+  </div>
+
+  <h3>Privacy-first</h3>
+
+  <p>There are no accounts on Gathio. When you create an event, we generate a password which allows you to edit the
+    event. Send all your guests the public link, and all your co-hosts the secret editing link containing the password.
+  </p>
+
+  <p>If you supply your email, we'll send you the editing password so you don't lose it - but supplying your email is
+    optional!</p>
+
+  <p>If this instance automatically deletes its events, sometime after the event finishes, it's deleted from the
+    database for ever, and your data goes with it.</p>
+
+  <p>Also, Gathio doesn't show you ads, doesn't sell your data, and never sends you unnecessary emails.</p>
+
+  <p>But remember: all events are visible to anyone who knows the link, so probably don't use Gathio to plot your
+    surprise birthday party or revolution. Or whatever, you do you.</p>
+
+  <h3>Configurable</h3>
+
+  <p>The <a href="https://gath.io">flagship Gathio instance at gath.io</a> is designed for anyone to create ephemeral,
+    hidden events. Anyone can create an event; events are never displayed anywhere public; and they're deleted 7 days
+    after they end.</p>
+
+  <p>But if your community sets up their own instance, you can limit event creation to a specific list of people,
+    display events on a handy list on the homepage, and disable event deletion entirely!</p>
+
+  <h3>Federation and self-hosting</h3>
+
+  <p>Gathio can easily be self-hosted, and supports ActivityPub services like Mastodon, Pleroma, and Friendica, allowing
+    you to access events from anywhere on the Fediverse. We encourage you to spin up your own instance for your
+    community. Detailed instructions on <a href="https://docs.gath.io/using-gathio/fediverse/">ActivityPub access</a>
+    and <a href="https://docs.gath.io/running-gathio/installation/">self-hosted installation</a>
+    live on our GitHub wiki.
+
+  <h3>Open source</h3>
+
+  <p>Gathio is delighted to be open source, and is built by a lovely group of people. Leave a question in our <a
+      href="https://github.com/lowercasename/gathio/issues">tracker</a> if you encounter any issues.</p>
+
+  {{#if showKofi}}
+  <div class="card border-secondary mt-5 mb-3 mx-auto" style="min-width:300px;max-width:50%;">
+    <div class="card-body text-secondary">
+      <p>If you find yourself using and enjoying Gathio, consider buying Raphael a coffee. It'll help keep the project
+        and main site running! <i class="far fa-heart"></i></p>
+      <script type='text/javascript' src='https://ko-fi.com/widgets/widget_2.js'></script>
+      <script
+        type='text/javascript'>kofiwidget2.init('Support Me on Ko-fi', '#46b798', 'Q5Q2O7T5'); kofiwidget2.draw();</script>
+    </div>
+  </div>
+  {{/if}}
 </main>


### PR DESCRIPTION
This updates the landing page, and also ActivityPub responses containing links to the Fediverse instructions, to point to the new docs site instead of to the wiki.