### PR TITLE
rsvp urls and notification added

### DIFF
--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -21,7 +21,8 @@ type EmailTemplateName =
     | "eventGroupUpdated"
     | "removeEventAttendee"
     | "subscribed"
-    | "unattendEvent";
+    | "unattendEvent"
+    | "rsvpNotification";
 
 export class EmailService {
     nodemailerTransporter: Transporter | undefined = undefined;

--- a/views/emails/addEventAttendee/addEventAttendeeHtml.handlebars
+++ b/views/emails/addEventAttendee/addEventAttendeeHtml.handlebars
@@ -1,5 +1,41 @@
 <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">{{t "views.emails.addeventattendee.preface" }}</p>
 <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">{{t "views.emails.addeventattendee.eventlink" }}: <a href="https://{{domain}}/{{eventID}}">https://{{domain}}/{{eventID}}</a></p>
+<!-- ────── NEW: Accept / Decline buttons ────── -->
+<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
+  <strong>RSVP:</strong>
+  <br/>
+  <a
+href="{{acceptUrl}}"
+style="
+  display: inline-block;
+  margin-right: 8px;
+  padding: 8px 12px;
+  color: #ffffff;
+  background-color: #28a745;
+  text-decoration: none;
+  border-radius: 4px;
+  font-weight: bold;
+"
+  >
+Accept
+  </a>
+  <a
+href="{{declineUrl}}"
+style="
+  display: inline-block;
+  padding: 8px 12px;
+  color: #ffffff;
+  background-color: #dc3545;
+  text-decoration: none;
+  border-radius: 4px;
+  font-weight: bold;
+"
+  >
+Decline
+  </a>
+</p>
+<!-- ──────────────────────────────────────────── -->
+
 <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">{{t "views.emails.addeventattendee.toremove" }}: <a href="https://{{domain}}/event/{{eventID}}/unattend/{{removalPasswordHash}}">{{t "views.emails.addeventattendee.clicktocancel" }}</a>.</p>
 <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">{{{t "views.emails.addeventattendee.removapasswordhtml" }}}: {{removalPassword}}</p>
 <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">{{t "views.emails.love" }}</p>

--- a/views/emails/addEventAttendee/addEventAttendeeText.handlebars
+++ b/views/emails/addEventAttendee/addEventAttendeeText.handlebars
@@ -2,6 +2,9 @@
 
 {{t "views.emails.addeventattendee.eventlink" }}: https://{{domain}}/{{eventID}}
 
+Accept: {{acceptUrl}}
+Decline: {{declineUrl}}
+
 {{t "views.emails.addeventattendee.removelink" }}: https://{{domain}}/event/{{eventID}}/unattend/{{removalPasswordHash}}
 
 {{t "views.emails.addeventattendee.removepassword" }}: {{removalPassword}}

--- a/views/emails/rsvpNotification/rsvpNotificationHtml.handlebars
+++ b/views/emails/rsvpNotification/rsvpNotificationHtml.handlebars
@@ -1,0 +1,18 @@
+<html>
+  <body>
+    <p>Hi {{hostName}},</p>
+
+    <p>
+      {{attendeeEmail}} has <strong>{{attendance}}</strong> your invitation to 
+      <a href="{{eventUrl}}">{{eventTitle}}</a>.
+    </p>
+
+    <p>
+      You can view the event page here: 
+      <a href="{{eventUrl}}">{{eventUrl}}</a>
+    </p>
+
+    <hr>
+    <p>Thanks for using {{siteName}}!</p>
+  </body>
+</html>

--- a/views/emails/rsvpNotification/rsvpNotificationText.handlebars
+++ b/views/emails/rsvpNotification/rsvpNotificationText.handlebars
@@ -1,0 +1,7 @@
+Hi {{hostName}},
+
+{{attendeeEmail}} has {{attendance}} your invitation to:
+  {{eventTitle}}
+  {{eventUrl}}
+
+Thanks for using {{siteName}}!


### PR DESCRIPTION
# Functionality of RSVP

## Generate accept and decline url for RSVP
1. Generate `ACCEPT` and `DECLINE` url. removalPassword is used to track the user
2. ACCEPT and DECLINE button added in `views/emails/addEventAttendee/addEventAttendeeHtml.handlebars`

## GET url to confirm or decline the RSVP
3. A new route created `GET:/event/:eventID/rsvp`

## Host receives notification
4. Host recieve notification of Accept or decline
5. for notification this template is added `views/emails/rsvpNotification/rsvpNotificationHtml.handlebars`

### For local testing
generate account for SMTP local here https://ethereal.email/
add this in config/config.toml
[nodemailer]
smtp_server = "smtp.ethereal.email"
smtp_port = "587"
smtp_username = ".x@ethereal.email"
smtp_password = "xx"
<img width="1280" alt="Screenshot 2025-06-01 at 1 28 48 PM" src="https://github.com/user-attachments/assets/bdd89cab-cb1f-49ec-8dd4-90db40d29ba1" />
<img width="1280" alt="Screenshot 2025-06-01 at 1 28 13 PM" src="https://github.com/user-attachments/assets/7ea57426-9884-4e59-bffa-95bca7cde7d6" />
<img width="1280" alt="Screenshot 2025-06-01 at 1 28 57 PM" src="https://github.com/user-attachments/assets/cf6136d0-7b0e-4941-bac7-693f4dd3ea4d" />
