### PR TITLE
Fix typo in comment placeholder text

### DIFF
--- a/views/event.handlebars
+++ b/views/event.handlebars
@@ -344,7 +344,7 @@
             <div class="col-md">
               <form id="replyForm" action="/post/reply/{{../eventData.id}}/{{this._id}}" method="post">
                 <div class="form-group">
-                  <input type="text" class="form-control form-control-sm" id="replyAuthor" name="replyAuthor" placeholder="Y{{t "views.event.attendeename" }}" required>
+                  <input type="text" class="form-control form-control-sm" id="replyAuthor" name="replyAuthor" placeholder="{{t "views.event.attendeename" }}" required>
                 </div>
                 <div class="form-group">
                   <div class="d-flex flex-gap">


### PR DESCRIPTION
The replyAuthor placeholder template has an extra Y in it so it renders as (eg in english) "YYour Name". This commit deletes the extra Y.