### PR TITLE
Fix download of ICS file

### DIFF
--- a/views/event.handlebars
+++ b/views/event.handlebars
@@ -505,7 +505,7 @@ window.eventData = {{{ json jsonData }}};
     }
 
     // From https://davidwalsh.name/javascript-download
-    function downloadFile(data, fileName, type="text/plain") {
+    function downloadFile(data, fileName, type="text/calendar") {
       // Create an invisible A element
       const a = document.createElement("a");
       a.style.display = "none";

--- a/views/eventgroup.handlebars
+++ b/views/eventgroup.handlebars
@@ -312,7 +312,7 @@ window.groupData = {{{ json jsonData }}};
     })
 
     // From https://davidwalsh.name/javascript-download
-    function downloadFile(data, fileName, type="text/plain") {
+    function downloadFile(data, fileName, type="text/calendar") {
       // Create an invisible A element
       const a = document.createElement("a");
       a.style.display = "none";


### PR DESCRIPTION
use mimetype `txt/calendar` when downloading the .ics file.

Resolves lowercasename#190