### PR TITLE
Remove edit token from "share this" link in Group HTML email

### DIFF
--- a/views/emails/createEventGroup/createEventGroupHtml.handlebars
+++ b/views/emails/createEventGroup/createEventGroupHtml.handlebars
@@ -18,7 +18,7 @@
     </tr>
   </tbody>
 </table>
-<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">{{t "views.emails.createeventgroup.sharelink" }}: <a href="https://{{domain}}/group/{{eventGroupID}}?e={{editToken}}">https://{{domain}}/group/{{eventGroupID}}</a></p>
+<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">{{t "views.emails.createeventgroup.sharelink" }}: <a href="https://{{domain}}/group/{{eventGroupID}}">https://{{domain}}/group/{{eventGroupID}}</a></p>
 <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">{{t "views.emails.createeventgroup.done" }}</p>
 <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">{{t "views.emails.love" }}</p>
 <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">{{siteName}}</p>


### PR DESCRIPTION
Hi! Stumbled upon this randomly with my self-hosted instance, copied the public link out of an email and was perplexed to find that it had the edit token embedded. :)