### PR TITLE
Fix same-day event creation with proper timezone handling

### DIFF
--- a/src/util/validation.ts
+++ b/src/util/validation.ts
@@ -88,27 +88,36 @@ const validateUrl = (url: string) => {
   return validUrl.protocol === "http:" || validUrl.protocol === "https:";
 };
 
-export const validateEventTime = (start: Date, end: Date): Error | boolean => {
-  if (moment(start).isAfter(moment(end))) {
+export const validateEventTime = (
+  start: string,
+  end: string,
+  timezone: string,
+): Error | boolean => {
+  // Parse the datetime-local values in the event's timezone
+  const startMoment = moment.tz(start, timezone);
+  const endMoment = moment.tz(end, timezone);
+  const now = moment();
+
+  if (startMoment.isAfter(endMoment)) {
     return {
       message: i18next.t("util.validation.eventtime.startisafter"),
       field: "eventStart",
     };
   }
-  if (moment(start).isBefore(moment())) {
+  if (startMoment.isBefore(now)) {
     return {
       message: i18next.t("util.validation.eventtime.startisbefore"),
       field: "eventStart",
     };
   }
-  if (moment(end).isBefore(moment())) {
+  if (endMoment.isBefore(now)) {
     return {
       message: i18next.t("util.validation.eventtime.endisbefore"),
       field: "eventEnd",
     };
   }
   // Duration cannot be longer than 1 year
-  if (moment(end).diff(moment(start), "years") > 1) {
+  if (endMoment.diff(startMoment, "years") > 1) {
     return {
       message: i18next.t("util.validation.eventtime.endyears"),
       field: "eventEnd",
@@ -154,8 +163,9 @@ export const validateEventData = (
     });
   }
   const timeValidation = validateEventTime(
-    new Date(validatedData.eventStart),
-    new Date(validatedData.eventEnd),
+    validatedData.eventStart,
+    validatedData.eventEnd,
+    validatedData.timezone,
   );
   if (timeValidation !== true && timeValidation !== false) {
     errors.push({


### PR DESCRIPTION
## Summary
- Fixed the date/time validation to use the event's timezone when checking if the start time is in the future
- Previously, `datetime-local` input values were parsed with `new Date()` which used the server's timezone, causing valid same-day events to be rejected
- Now uses `moment.tz()` to properly interpret dates in the event's specified timezone

## Test plan
- [x] Tested in Docker that creating an event 1 hour from now succeeds
- [x] Tested in Docker that creating an event in the past still fails with "Start time must be in the future"
- [x] All 13 existing Cypress tests pass

Fixes #179