### PR TITLE
fix(#247): add configurable max comment length

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -23,6 +23,8 @@ show_kofi = false
 # Show a list of events and groups on the front page which have been marked as
 # 'Display this event/group on the public event/group list'.
 show_public_event_list = false
+# Maximum number of characters allowed in an event comment or reply.
+max_comment_length = 5000
 # Which mail service to use to send emails to hosts and attendees. Options are
 # 'nodemailer', 'sendgrid', or 'none'. Configure settings for this mail
 # service below.

--- a/cypress/e2e/event.cy.ts
+++ b/cypress/e2e/event.cy.ts
@@ -99,6 +99,36 @@ describe("Events", () => {
     cy.get(".comment").should("contain.text", "Test Comment");
   });
 
+  it("rejects comments longer than the configured limit", function () {
+    cy.setCookie(
+      "cypressConfigOverride",
+      JSON.stringify({
+        general: {
+          max_comment_length: 10,
+        },
+      }),
+    );
+    cy.visit(`/${this.eventID}`);
+    cy.get("#commentContent").should("have.attr", "maxlength", "10");
+
+    cy.request({
+      method: "POST",
+      url: `/post/comment/${this.eventID}/`,
+      form: true,
+      failOnStatusCode: false,
+      body: {
+        commentAuthor: "Test Author",
+        commentContent: "12345678901",
+      },
+    }).then((response) => {
+      expect(response.status).to.eq(400);
+      expect(response.body).to.contain("at most 10 characters");
+    });
+
+    cy.visit(`/${this.eventID}`);
+    cy.get(".comment").should("not.exist");
+  });
+
   it("displays the ActivityPub featured post", function () {
     cy.log(this.eventID);
 

--- a/locales/de.json
+++ b/locales/de.json
@@ -36,6 +36,7 @@
   "frontend.timeformat": "H:mm",
   "routes.addeventattendeesubject": "Du bist für {{ eventName }} angemeldet",
   "routes.addeventcommentsubject": "Neuer Kommentar in {{eventName}}",
+  "routes.commenttoolong": "Kommentare und Antworten dürfen höchstens {{maxCommentLength}} Zeichen lang sein.",
   "routes.deleteeventsubject": "{{ eventName }} wurde gelöscht",
   "routes.event.datetimeformat": "{{thedate, intlDate}}",
   "routes.event.descriptionchanged": "Die Veranstaltungsbeschreibung wurde geändert",

--- a/locales/en.json
+++ b/locales/en.json
@@ -36,6 +36,7 @@
   "frontend.timeformat": "h:mm a",
   "routes.addeventattendeesubject": "You're RSVPed to {{ eventName }}",
   "routes.addeventcommentsubject": "New comment in {{eventName}}",
+  "routes.commenttoolong": "Comments and replies must be at most {{maxCommentLength}} characters long.",
   "routes.attendeeawaitingapprovalsubject": "New attendee awaiting approval for {{ eventName }}",
   "routes.attendeependingconfirmationsubject": "Your RSVP to {{ eventName }} is pending approval",
   "routes.attendeeapprovedsubject": "You've been approved to attend {{ eventName }}",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -36,6 +36,7 @@
   "frontend.timeformat": "LT",
   "routes.addeventattendeesubject": "{{ eventName }} への参加を登録しました",
   "routes.addeventcommentsubject": "{{ eventName }} にコメントがきました",
+  "routes.commenttoolong": "コメントと返信は {{maxCommentLength}} 文字以内にしてください。",
   "routes.deleteeventsubject": "{{ eventName }} は削除されました",
   "routes.event.datetimeformat": "{{thedate, long}}",
   "routes.event.descriptionchanged": "説明が変更",

--- a/locales/nn.json
+++ b/locales/nn.json
@@ -36,6 +36,7 @@
   "frontend.timeformat": "HH.mm",
   "routes.addeventattendeesubject": "Du er meldt på {{ eventName }}",
   "routes.addeventcommentsubject": "Ny kommentar i {{eventName}}",
+  "routes.commenttoolong": "Kommentarar og svar kan vere høgst {{maxCommentLength}} teikn lange.",
   "routes.deleteeventsubject": "{{ eventName }} vart sletta",
   "routes.event.datetimeformat": "{{thedate, intlDate}}",
   "routes.event.descriptionchanged": "skildringa av arrangementet vart endra",

--- a/src/activitypub.ts
+++ b/src/activitypub.ts
@@ -5,7 +5,7 @@ import { customAlphabet } from "nanoid";
 import moment from "moment-timezone";
 import i18next from "i18next";
 import sanitizeHtml from "sanitize-html";
-import { getConfig } from "./lib/config.js";
+import { getConfig, getMaxCommentLength } from "./lib/config.js";
 const config = getConfig();
 const domain = config.general.domain;
 const siteName = config.general.site_name;
@@ -884,15 +884,22 @@ async function _handleCreateNoteComment(req: Request, res: Response) {
     const parsedActor = await signedFetch(req.body.actor, eventID);
     const name =
       parsedActor.preferredUsername || parsedActor.name || req.body.actor;
+    const content = sanitizeHtml(req.body.object.content, {
+      allowedTags: [],
+      allowedAttributes: {},
+    }).replace(`@${eventID}`, "");
+    const maxCommentLength = getMaxCommentLength(res.locals.config);
+    if (content.length > maxCommentLength) {
+      return res
+        .status(400)
+        .send(i18next.t("routes.commenttoolong", { maxCommentLength }));
+    }
     const newComment = {
       id: commentID,
       actorId: req.body.actor,
       activityId: req.body.object.id,
       author: name,
-      content: sanitizeHtml(req.body.object.content, {
-        allowedTags: [],
-        allowedAttributes: {},
-      }).replace(`@${eventID}`, ""),
+      content,
       timestamp: moment().toDate(),
       activityJson: JSON.stringify(req.body),
       actorJson: JSON.stringify(parsedActor),

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -22,6 +22,7 @@ export interface GathioConfig {
     email_logo_url: string;
     show_kofi: boolean;
     show_public_event_list: boolean;
+    max_comment_length: number;
     mail_service: "nodemailer" | "sendgrid" | "mailgun" | "none";
     creator_email_addresses: string[];
   };
@@ -54,9 +55,12 @@ interface FrontendConfig {
   showKofi: boolean;
   showPublicEventList: boolean;
   showInstanceInformation: boolean;
+  maxCommentLength: number;
   staticPages?: StaticPage[];
   version: string;
 }
+
+export const DEFAULT_MAX_COMMENT_LENGTH = 5000;
 
 const defaultConfig: GathioConfig = {
   general: {
@@ -69,6 +73,7 @@ const defaultConfig: GathioConfig = {
     email_logo_url: "",
     show_public_event_list: false,
     show_kofi: false,
+    max_comment_length: DEFAULT_MAX_COMMENT_LENGTH,
     mail_service: "none",
     creator_email_addresses: [],
   },
@@ -88,6 +93,7 @@ export const frontendConfig = (res: Response): FrontendConfig => {
       showPublicEventList: defaultConfig.general.show_public_event_list,
       showKofi: defaultConfig.general.show_kofi,
       showInstanceInformation: false,
+      maxCommentLength: getMaxCommentLength(),
       staticPages: [],
       version: process.env.npm_package_version || "unknown",
     };
@@ -100,9 +106,25 @@ export const frontendConfig = (res: Response): FrontendConfig => {
     showPublicEventList: !!config.general.show_public_event_list,
     showKofi: !!config.general.show_kofi,
     showInstanceInformation: !!config.static_pages?.length,
+    maxCommentLength: getMaxCommentLength(config),
     staticPages: config.static_pages,
     version: process.env.npm_package_version || "unknown",
   };
+};
+
+export const getMaxCommentLength = (
+  config: Pick<GathioConfig, "general"> | null = null,
+): number => {
+  const value = config?.general.max_comment_length;
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    value < 1 ||
+    !Number.isInteger(value)
+  ) {
+    return DEFAULT_MAX_COMMENT_LENGTH;
+  }
+  return value;
 };
 
 interface InstanceRule {

--- a/src/routes.js
+++ b/src/routes.js
@@ -682,13 +682,11 @@ router.post("/post/comment/:eventID", (req, res) => {
   const commentContent =
     typeof req.body.commentContent === "string" ? req.body.commentContent : "";
   if (commentContent.length > maxCommentLength) {
-    return res
-      .status(400)
-      .send(
-        i18next.t("routes.commenttoolong", {
-          maxCommentLength,
-        }),
-      );
+    return res.status(400).send(
+      i18next.t("routes.commenttoolong", {
+        maxCommentLength,
+      }),
+    );
   }
   let commentID = nanoid();
   const newComment = {
@@ -791,13 +789,11 @@ router.post("/post/reply/:eventID/:commentID", (req, res) => {
   const replyContent =
     typeof req.body.replyContent === "string" ? req.body.replyContent : "";
   if (replyContent.length > maxCommentLength) {
-    return res
-      .status(400)
-      .send(
-        i18next.t("routes.commenttoolong", {
-          maxCommentLength,
-        }),
-      );
+    return res.status(400).send(
+      i18next.t("routes.commenttoolong", {
+        maxCommentLength,
+      }),
+    );
   }
   let replyID = nanoid();
   let commentID = req.params.commentID;

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,7 +1,12 @@
 import fs from "fs";
 import express from "express";
 import { customAlphabet } from "nanoid";
-import { frontendConfig, getConfig } from "./lib/config.js";
+import {
+  frontendConfig,
+  getConfig,
+  getMaxCommentLength,
+} from "./lib/config.js";
+import { getConfigMiddleware } from "./lib/middleware.js";
 import { addToLog } from "./helpers.js";
 import moment from "moment-timezone";
 import crypto from "crypto";
@@ -29,6 +34,7 @@ const nanoid = customAlphabet(
 
 const router = express.Router();
 router.use(fileUpload());
+router.use(getConfigMiddleware);
 
 // SCHEDULED DELETION
 schedule.scheduleJob("59 23 * * *", function (_fireDate) {
@@ -672,11 +678,23 @@ router.get("/unsubscribe/:eventGroupID", (req, res) => {
 });
 
 router.post("/post/comment/:eventID", (req, res) => {
+  const maxCommentLength = getMaxCommentLength(res.locals.config);
+  const commentContent =
+    typeof req.body.commentContent === "string" ? req.body.commentContent : "";
+  if (commentContent.length > maxCommentLength) {
+    return res
+      .status(400)
+      .send(
+        i18next.t("routes.commenttoolong", {
+          maxCommentLength,
+        }),
+      );
+  }
   let commentID = nanoid();
   const newComment = {
     id: commentID,
     author: req.body.commentAuthor,
-    content: req.body.commentContent,
+    content: commentContent,
     timestamp: moment(),
   };
 
@@ -769,12 +787,24 @@ router.post("/post/comment/:eventID", (req, res) => {
 });
 
 router.post("/post/reply/:eventID/:commentID", (req, res) => {
+  const maxCommentLength = getMaxCommentLength(res.locals.config);
+  const replyContent =
+    typeof req.body.replyContent === "string" ? req.body.replyContent : "";
+  if (replyContent.length > maxCommentLength) {
+    return res
+      .status(400)
+      .send(
+        i18next.t("routes.commenttoolong", {
+          maxCommentLength,
+        }),
+      );
+  }
   let replyID = nanoid();
   let commentID = req.params.commentID;
   const newReply = {
     id: replyID,
     author: req.body.replyAuthor,
-    content: req.body.replyContent,
+    content: replyContent,
     timestamp: moment(),
   };
   Event.findOne(

--- a/views/event.handlebars
+++ b/views/event.handlebars
@@ -367,7 +367,7 @@
       <label for="commentContent">{{t "views.event.comment" }}</label>
       <div class="form-group">
         <div class="d-flex flex-gap">
-          <textarea class="form-control" id="commentContent" name="commentContent" style="resize: none;" placeholder="{{t "views.event.commentcontent" }}" required></textarea>
+          <textarea class="form-control" id="commentContent" name="commentContent" style="resize: none;" placeholder="{{t "views.event.commentcontent" }}" maxlength="{{maxCommentLength}}" required></textarea>
           <div class="input-group-append">
             <button type="submit" class="button button--primary" id="postComment">{{t "views.event.postbutton" }} <i class="fas fa-chevron-right"></i></button>
           </div>
@@ -418,7 +418,7 @@
                 </div>
                 <div class="form-group">
                   <div class="d-flex flex-gap">
-                    <textarea class="form-control form-control-sm" id="replyContent" name="replyContent" style="resize: none;" placeholder="{{t "views.event.replycontent" }}" required></textarea>
+                    <textarea class="form-control form-control-sm" id="replyContent" name="replyContent" style="resize: none;" placeholder="{{t "views.event.replycontent" }}" maxlength="{{maxCommentLength}}" required></textarea>
                     <div class="input-group-append">
                     </div>
                       <button type="submit" class="button button--primary button--sm" id="postReply">{{t "views.event.reply" }} <i class="fas fa-chevron-right"></i></button>


### PR DESCRIPTION
Fixes #247 

## Summary

Adds a configurable maximum length for event comments and replies.

This introduces a per-instance `general.max_comment_length` setting with a default of `5000`, and enforces the limit server-side for:

- web comments
- web replies
- ActivityPub-ingested comments

The event page also reflects the limit in the comment and reply form `maxlength` attributes.

## Why?

Comments are currently stored inline on the `Event` document and had no length limit. This allowed extremely large individual comments, which could be abused and also increased the risk of hitting MongoDB's document size limit.

This change adds a hard cap for individual comment bodies and makes that cap configurable per instance.

## Implementation

- added `general.max_comment_length` to config handling and `config.example.toml`
- added a shared config helper for resolving the effective max comment length
- enforced the limit in `POST /post/comment/:eventID`
- enforced the limit in `POST /post/reply/:eventID/:commentID`
- enforced the limit for ActivityPub `Create/Note` comments after sanitization
- added localized error messages
- added `maxlength` to the comment and reply textareas
- added a Cypress test covering a lowered configured limit

## Notes

This reduces the risk of oversized comment payloads, but does not completely eliminate the possibility of an event document eventually exceeding MongoDB's maximum document size, since comments are still embedded on the `Event` document.

## Testing

Implemented a Cypress regression test for the configured limit behavior.