### PR TITLE
Only expose group edit token to editors

### DIFF
--- a/src/routes/frontend.ts
+++ b/src/routes/frontend.ts
@@ -570,9 +570,10 @@ router.get("/:eventID", async (req: Request, res: Response) => {
           eventGroupID: event.eventGroup
             ? (event.eventGroup as unknown as IEventGroup).id
             : null,
-          eventGroupEditToken: event.eventGroup
-            ? (event.eventGroup as unknown as IEventGroup).editToken
-            : null,
+          eventGroupEditToken:
+            editingEnabled && event.eventGroup
+              ? (event.eventGroup as unknown as IEventGroup).editToken
+              : null,
           usersCanAttend: event.usersCanAttend,
           usersCanComment: event.usersCanComment,
           maxAttendees: event.maxAttendees,


### PR DESCRIPTION
The public event page renders `window.eventData` with a `jsonData` blob. For events in a group, that blob included the group's `editToken` for *every* visitor — so anyone viewing a grouped event could grab the group edit token from page source and edit/delete the whole group.

This gates `eventGroupEditToken` behind `editingEnabled`, same as we already do for the event's own `editToken` right below it. Only the edit-mode JS (`event-edit.js`, `group-linker.js`) uses this value, and that only loads inside `{{#if editingEnabled}}`, so nothing else breaks.

`tsc` passes.