### PR TITLE
Stabilize attend modal typing in Cypress specs

### DIFF
--- a/cypress/e2e/attendeeApproval.cy.ts
+++ b/cypress/e2e/attendeeApproval.cy.ts
@@ -12,6 +12,10 @@ function rsvpAsGuest(eventID: string, name: string) {
   visitFresh(`/${eventID}`);
   cy.get("button#attendEvent").click();
   cy.get("#attendModal").should("be.visible");
+  // Wait for Bootstrap's fade transition to finish - when it does, the modal
+  // steals focus (Bootstrap calls modal.focus() on shown), silently
+  // swallowing any keystrokes typed mid-transition
+  cy.get("#attendModal").should("have.focus");
   cy.get("#attendeeName").type(name);
   cy.get("form#attendEventForm").submit();
   cy.get("#rsvpSuccessModal", { timeout: 10000 }).should("be.visible");
@@ -109,6 +113,7 @@ describe("Attendee Approval Feature", () => {
       // RSVP to the event
       cy.get("button#attendEvent").click();
       cy.get("#attendModal").should("be.visible");
+      cy.get("#attendModal").should("have.focus");
       cy.get("#attendeeName").type("Regular Guest");
       cy.get("form#attendEventForm").submit();
 
@@ -121,6 +126,7 @@ describe("Attendee Approval Feature", () => {
 
       cy.get("button#attendEvent").click();
       cy.get("#attendModal").should("be.visible");
+      cy.get("#attendModal").should("have.focus");
       cy.get("#attendeeName").type("Regular Guest");
       cy.get("form#attendEventForm").submit();
 
@@ -149,6 +155,7 @@ describe("Attendee Approval Feature", () => {
 
       cy.get("button#attendEvent").click();
       cy.get("#attendModal").should("be.visible");
+      cy.get("#attendModal").should("have.focus");
       cy.get("#attendeeName").type("Pending Guest");
       cy.get("#removalPassword").invoke("val").as("guestPassword");
       cy.get("form#attendEventForm").submit();
@@ -169,6 +176,7 @@ describe("Attendee Approval Feature", () => {
 
       cy.get("button#attendEvent").click();
       cy.get("#attendModal").should("be.visible");
+      cy.get("#attendModal").should("have.focus");
       cy.get("#attendeeName").type("First Guest");
       cy.get("form#attendEventForm").submit();
 

--- a/cypress/e2e/event.cy.ts
+++ b/cypress/e2e/event.cy.ts
@@ -68,6 +68,10 @@ describe("Events", () => {
 
   it("allows you to attend an event - visible in public list", function () {
     cy.get("button#attendEvent").click();
+    cy.get("#attendModal").should("be.visible");
+    // The focus wait sees out Bootstrap's fade transition, which ends by
+    // stealing focus to the modal, swallowing keystrokes typed until then
+    cy.get("#attendModal").should("have.focus");
     cy.get("#attendeeName").type("Test Attendee");
     cy.get("#attendeeNumber").focus();
     cy.get("#attendeeNumber").clear();
@@ -79,6 +83,8 @@ describe("Events", () => {
 
   it("allows you to attend an event - hidden from public list", function () {
     cy.get("button#attendEvent").click();
+    cy.get("#attendModal").should("be.visible");
+    cy.get("#attendModal").should("have.focus");
     cy.get("#attendeeName").type("Test Attendee");
     cy.get("#attendeeNumber").focus();
     cy.get("#attendeeNumber").clear();
@@ -305,6 +311,8 @@ describe("Events", () => {
 
   it("removes you from the event with a one-click unattend link", function () {
     cy.get("button#attendEvent").click();
+    cy.get("#attendModal").should("be.visible");
+    cy.get("#attendModal").should("have.focus");
     cy.get("#attendeeName").type("Test Attendee");
     cy.get("#attendeeNumber").focus();
     cy.get("#attendeeNumber").clear();


### PR DESCRIPTION
Fixes the recurring CI flake where attendee names were truncated mid-typing (e.g. 'Regular Gues') — Bootstrap steals focus to the modal when its fade transition ends, swallowing in-flight keystrokes on slow runners. Adds the same modal-focus wait that customQuestions.cy.ts already uses to every attend-modal typing site. Test-only change.