### PR TITLE
Fix banner image rendering on mobile

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -6,10 +6,9 @@
   font-stretch: 100%;
   font-display: swap;
   src: url("/fonts/fredoka-v14.woff2") format("woff2");
-  unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
-    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
-    U+2215, U+FEFF, U+FFFD;
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+    U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
+    U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 body {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -6,9 +6,10 @@
   font-stretch: 100%;
   font-display: swap;
   src: url("/fonts/fredoka-v14.woff2") format("woff2");
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
-    U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
-    U+2212, U+2215, U+FEFF, U+FFFD;
+  unicode-range:
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+    U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212,
+    U+2215, U+FEFF, U+FFFD;
 }
 
 body {
@@ -563,11 +564,16 @@ ul#sidebar__nav a {
 }
 
 #eventImageContainer {
-  height: 300px;
-  background-size: cover;
-  background-repeat: no-repeat;
-  background-position: center;
+  position: relative;
   border-radius: 5px;
+  overflow: hidden;
+}
+
+#eventImageContainer img {
+  max-height: 300px;
+  display: block;
+  width: 100%;
+  height: auto;
 }
 
 #eventImageContainer:before {
@@ -580,8 +586,8 @@ ul#sidebar__nav a {
     rgba(255, 255, 255, 1) 100%
   );
   position: absolute;
-  width: 100%;
-  height: 300px;
+  inset: 0;
+  pointer-events: none;
 }
 
 #event__basics {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -574,6 +574,7 @@ ul#sidebar__nav a {
   display: block;
   width: 100%;
   height: auto;
+  object-fit: cover;
 }
 
 #eventImageContainer:before {

--- a/views/event.handlebars
+++ b/views/event.handlebars
@@ -5,7 +5,9 @@
 </div>
 {{/if}}
 {{#if eventHasCoverImage}}
-  <div class="event-header-image" id="eventImageContainer" style="background-image: url(/events/{{eventData.image}});"></div>
+  <div class="event-header-image" id="eventImageContainer">
+    <img src="/events/{{eventData.image}}" alt="">
+  </div>
 {{else}}
   <div class="event-header-image" id="genericEventImageContainer" style="background-image: url(/images/seigaiha.png);"></div>
 {{/if}}

--- a/views/eventgroup.handlebars
+++ b/views/eventgroup.handlebars
@@ -5,7 +5,9 @@
 </div>
 {{/if}}
 {{#if eventGroupHasCoverImage}}
-  <div class="event-header-image" id="eventImageContainer" style="background-image: url(/events/{{eventGroupData.image}});"></div>
+  <div class="event-header-image" id="eventImageContainer">
+    <img src="/events/{{eventGroupData.image}}" alt="">
+  </div>
 {{else}}
   <div class="event-header-image" id="genericEventImageContainer" style="background-image: url(/images/seigaiha.png);"></div>
 {{/if}}


### PR DESCRIPTION
Currently, if an event host uploads a banner image, it appears cut off on mobile.

Closes #171 

Here's what that looks like today:

<img width="1449" height="2961" alt="gathio-mobile-banner-cut-off" src="https://github.com/user-attachments/assets/95cba193-9ce2-48ce-a3ce-05da2bc45e8a" />

With this PR, it is now fit to the viewport width:

<img width="1449" height="2961" alt="gathio-mobile-banner-fit" src="https://github.com/user-attachments/assets/b88e8bcf-4019-4ee3-97b4-86ba56447ae1" />

Banner images still render the same on desktop:

<img width="1920" height="1080" alt="gathio-desktop-banner-unchanged" src="https://github.com/user-attachments/assets/5eec448d-5bfb-49d4-a661-adf190ba3a05" />