### PR TITLE
fix: preserve line breaks in comments

### DIFF
--- a/cypress/e2e/event.cy.ts
+++ b/cypress/e2e/event.cy.ts
@@ -96,16 +96,18 @@ describe("Events", () => {
     cy.get(".attendeesList").should("contain.text", "hidden");
   });
 
-  it("allows you to comment on an event", function () {
+  it("allows you to comment on an event with line breaks", function () {
     cy.get("#commentAuthor").type("Test Author");
-    cy.get("#commentContent").type("Test Comment");
+    cy.get("#commentContent").type("First Line{enter}Second Line");
     cy.get("#postComment").click();
     cy.get(".comment").should("contain.text", "Test Author");
-    cy.get(".comment").should("contain.text", "Test Comment");
+    cy.get(".commentContent")
+      .should("contain.text", "First Line\nSecond Line")
+      .and("have.css", "white-space", "pre-line");
   });
 
   // Regression test for #250, where every reply failed with a database error
-  it("allows you to reply to a comment", function () {
+  it("allows you to reply to a comment with line breaks", function () {
     cy.get("#commentAuthor").type("Test Author");
     cy.get("#commentContent").type("Test Comment");
     cy.get("#postComment").click();
@@ -113,12 +115,13 @@ describe("Events", () => {
 
     cy.get(".comment .openReplyBox").first().click();
     cy.get(".comment #replyAuthor").type("Reply Author");
-    cy.get(".comment #replyContent").type("Test Reply");
+    cy.get(".comment #replyContent").type("First Line{enter}Second Line");
     cy.get(".comment #postReply").click();
 
-    cy.get(".comment .repliesContainer")
-      .should("contain.text", "Reply Author")
-      .and("contain.text", "Test Reply");
+    cy.get(".comment .repliesContainer").should("contain.text", "Reply Author");
+    cy.get(".comment .repliesContainer .commentContent")
+      .should("contain.text", "First Line\nSecond Line")
+      .and("have.css", "white-space", "pre-line");
     cy.contains("Database error").should("not.exist");
   });
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -804,6 +804,10 @@ ul#sidebar__nav a {
   border: 1px solid #dfdfdf;
 }
 
+.commentContent {
+  white-space: pre-line;
+}
+
 .replyContainer {
   display: none;
   background: #efefef;

--- a/views/event.handlebars
+++ b/views/event.handlebars
@@ -403,13 +403,13 @@
               {{else}}
                 <p class="mb-0"><strong>{{this.author}}</strong> <small class="commentTimestamp text-muted">{{this.timestamp}}</small></p>
               {{/if}}
-              <p>{{this.content}}</p>
+              <p class="commentContent">{{this.content}}</p>
               {{#if this.replies}}
                 <hr>
                 <div class="repliesContainer">
                   {{#each this.replies}}
                     <p class="mb-0"><strong><i class="fas fa-reply text-muted"></i> {{this.author}}</strong> <small class="commentTimestamp text-muted">{{this.timestamp}}</small></p>
-                    <p>{{this.content}}</p>
+                    <p class="commentContent">{{this.content}}</p>
                   {{/each}}
                 </div>
               {{/if}}


### PR DESCRIPTION
Fixes #260

Preserves line breaks in event comments and replies using a new `.commentContent` CSS class with `white-space: pre-line`, while keeping comment content safely rendered as plain text.

Tests:

- Updated Cypress coverage for multiline comments and replies
- `pnpm lint`
- `pnpm build`
- Full Cypress suite
- Manual browser check of multiline comments and replies